### PR TITLE
Remove line on switching VDSes

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -190,7 +190,6 @@ This document establishes a registry of verifiable data structure algorithms, wi
 Proof types are specific to their associated "verifiable data structure", for example, different Merkle trees might support different representations of "inclusion proof" or "consistency proof".
 Implementers should not expect interoperability across "verifiable data structures", but they should expect conceptually similar properties across the different registered proof types.
 For example, 2 different merkle tree based verifiable data structures might both support proofs of inclusion.
-Protocols requiring proof of inclusion ought to be able to preserve their functionality, while switching from one verifiable data structure to another, so long as both structures support the same proof types.
 Security analysis SHOULD be conducted prior to migrating to new structures to ensure the new security and privacy assumptions are acceptable for the use case.
 When designing new verifiable data structure parameters (or proof types), please start with -1, and count down for each proof type supported by your verifiable data structure:
 


### PR DESCRIPTION
I suggest removing the line on migrating between VDSes. I think it's good that the draft addresses an overlap in VDPs. However, I fear that the line I suggest removing might invite people to _not_ worry about security. I think it could be parsed as: "Probably, switching works."

Without the line, I think the draft now emphasizes that (a) you shouldn't expect that overlap in similar concepts leads to the same result, and (b) you must always consider security when migrating.