### PR TITLE
re issue#20 make accounting for hash algorithm agility explicit

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -257,6 +257,11 @@ Each specification MUST define how to encode the verifiable data structure and i
 Each specification MUST define how to produce and consume the supported proof types.
 See {{sec-rfc-9162-verifiable-data-structure-definition}} as an example.
 
+Where a specification supports a choice of hash algorithm,
+a registration must be made for each individually supported algorithm.
+For example, to provide for both SHA256 and SHA3_256 with {{RFC9162}},
+both "RFC9162_SHA256" and "RFC9162_SHA3_256" require entries in the relevant registries.
+
 # RFC9162_SHA256 {#sec-rfc-9162-verifiable-data-structure-definition}
 
 This section defines how the data structures described in {{-certificate-transparency-v2}} are mapped to the terminology defined in this document, using CBOR and COSE.


### PR DESCRIPTION
The example RFC9162 supports hash algorithm agility. This change makes the implied requirement to register each "instantiation" seperately explicit.