### PR TITLE
re issue#20 encourage use of detached payloads for proof formats

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -292,7 +292,7 @@ inclusion-proof = bstr .cbor [
 ### Receipt of Inclusion
 
 In a signed inclusion proof, the previous merkle tree root, maps to tree-size-1, and is a detached payload.
-In general, all specifications are encouraged to make proof payloads detached in this way where possible.
+Specifications are encouraged to make payloads detached when possible, forcing validation-time comparison.
 Profiles of proof signatures are encouraged to make additional protected header parameters mandatory, to ensure that claims are processed with their intended semantics.
 One way to include this information in the COSE structure is use of the typ (type) Header Parameter, see {{-cose-typ}} and the similar guidance provided in {{-cwt-header-claims}}.
 The protected header for an RFC9162_SHA256 inclusion proof signature is:

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -271,6 +271,7 @@ See {{-certificate-transparency-v2}}, 2.1.1. Definition of the Merkle Tree, for 
 ## Inclusion Proof {#sec-rfc9162-sha256-inclusion-proof}
 
 See {{-certificate-transparency-v2}}, 2.1.3.1. Generating an Inclusion Proof, for a complete description of this verifiable data structure proof type.
+
 The CBOR representation of an inclusion proof for RFC9162_SHA256 is:
 
 ~~~~ cddl
@@ -291,6 +292,7 @@ inclusion-proof = bstr .cbor [
 ### Receipt of Inclusion
 
 In a signed inclusion proof, the previous merkle tree root, maps to tree-size-1, and is a detached payload.
+In general, all specifications are encouraged to make proof payloads detached in this way where possible.
 Profiles of proof signatures are encouraged to make additional protected header parameters mandatory, to ensure that claims are processed with their intended semantics.
 One way to include this information in the COSE structure is use of the typ (type) Header Parameter, see {{-cose-typ}} and the similar guidance provided in {{-cwt-header-claims}}.
 The protected header for an RFC9162_SHA256 inclusion proof signature is:


### PR DESCRIPTION
It seems like a generaly strong and useful property that proof formats require that the payload be re-constructed from the proof prior to signature verification

This change adds a single scentence to the example inclusion proof to encourage this.