### PR TITLE
Address elements of Linda Dunbar's review

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -122,7 +122,7 @@ Verifiable Data Structure Proofs (VDP):
 Proof Type:
 
 : A property that can be obtained by verifying a given proof over one or more entries in a Verifiable Data Structure.
-  For example, a VDS, such as a binary merkle tree, can support proofs of type "inclusion" where each proof confirms that a given entry is included in a Merkle root.
+  For example, a VDS, such as a binary Merkle tree, can support proofs of type "inclusion" where each proof confirms that a given entry is included in a Merkle root.
 
 Proof Value:
 


### PR DESCRIPTION
One bit of the review is addressed by #55, this adds:

1. Consistent use of `(requested assignment ...)` next to TBD_* to resolve consistency. We could also change to the allocated valued everywhere, but the consensus in the last meeting was against that.
2. Rephrase the Proof Type to be hopefully more understandable, but without changing its meaning.

I have left the COSE Receipts definition unchanged, because although it is a little awkward, it is consistent with other header parameter definitions that follow, and I don't think it is ambiguous.