### PR TITLE
Drop statement about EC2 keys

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -147,7 +147,6 @@ The design of these structures is influenced by the conventions established for 
 ## Structures {#sec-cose-verifiable-data-structures}
 
 Similar to [COSE Key Types](https://www.iana.org/assignments/cose/cose.xhtml#key-type), different verifiable data structures support different algorithms.
-As EC2 keys (1: 2) support both digital signature and key agreement algorithms, RFC9162_SHA256 (TBD_1 (requested assignment 395) : 1) supports both inclusion and consistency proofs.
 
 This document establishes a registry of verifiable data structure algorithms, with the following initial contents:
 


### PR DESCRIPTION
Towards #57 

> Section 4.1 For a non-expert reader,  EC2 keys (1: 2) is basically meaningless especially (1: 2).

The sentence does not make sense to me, inclusion and consistency proofs only require signing, not key exchange, I am not sure what it is trying to say.