### PR TITLE
Security analysis MUST be conducted

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -172,7 +172,7 @@ This document establishes a registry of verifiable data structure algorithms, wi
 Proof types are specific to their associated "verifiable data structure", for example, different Merkle trees might support different representations of "inclusion proof" or "consistency proof".
 Implementers should not expect interoperability across "verifiable data structures", but they should expect conceptually similar properties across the different registered proof types.
 For example, 2 different Merkle tree based verifiable data structures might both support proofs of inclusion.
-Security analysis SHOULD be conducted prior to migrating to new structures to ensure the new security and privacy assumptions are acceptable for the use case.
+Security analysis MUST be conducted prior to migrating to new structures to ensure the new security and privacy assumptions are acceptable for the use case.
 
 ## Usage {#receipt-spec}
 


### PR DESCRIPTION
Towards #57 

> Section 4.2 Security analysis SHOULD be conducted why not a "MUST" and it a "SHOULD", then explain why and when the "SHOULD" can be bypassed.

Migrating without security analysis seems unjustifiable to me.