### PR TITLE
Use TBD_* consistently

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -176,7 +176,7 @@ Security analysis SHOULD be conducted prior to migrating to new structures to en
 
 ## Usage {#receipt-spec}
 
-This document registers a new COSE Header Parameter `receipts` (TBD_0) to enable this Receipts to be conveyed in the protected and unprotected headers of COSE Objects.
+This document registers a new COSE Header Parameter `receipts` (TBD_0 (requested assignment 394)) to enable this Receipts to be conveyed in the protected and unprotected headers of COSE Objects.
 
 When the receipts header parameter is present, the associated verifiable data structure and verifiable data structure proofs MUST match entries present in the registries established in this specification.
 


### PR DESCRIPTION
All references to early allocated labels now use TBD_* (towards #57), _except_ those that are in CDDL to avoid breaking CDDL validation.

> Section 4.3 Should it be "TBD_0" in This document registered a new COSE Header Parameter receipts (394) ? Also in Figure 1.
> Section 5.2.1 Please replace 395 & co with TBC_* (not repeating this further).

I have therefore deliberately _not updated_ figure 1. Considering these values have been been early allocated too (see https://www.iana.org/assignments/cose/cose.xhtml), I think this is reasonable.