### PR TITLE
Stating the obvious

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -505,10 +505,7 @@ It is recommended that implementations return a single boolean result for Receip
 
 # Privacy Considerations
 
-See the privacy considerations section of:
-
-- {{-certificate-transparency-v2}}
-- {{-COSE}}
+The privacy considerations section of {{-certificate-transparency-v2}} and {{-COSE}} apply to this document.
 
 ## Log Length
 


### PR DESCRIPTION
Towards #57

> Section 6 Sometimes it is better to state the obvious and state that the privacy considerations of the 2 RFCs also apply to this document.