### PR TITLE
Add specific pointer to Specification Required policy in RFC 8126

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -582,7 +582,7 @@ The map labels in the "vdp" are assigned from the COSE Verifiable Data Structure
 
 ## Verifiable Data Structure Registries
 
-IANA established the COSE Verifiable Data Structures and COSE Verifiable Data Structure Proofs registries under a Specification Required policy as described in {{RFC8126}}.
+IANA established the COSE Verifiable Data Structures and COSE Verifiable Data Structure Proofs registries under a Specification Required policy as described in {{Section 4.6 of RFC8126}}.
 
 ### Expert Review
 Expert reviewers should take into consideration the following points:


### PR DESCRIPTION
Towards #64 

> IANA established the COSE Verifiable Data Structures and COSE
Verifiable Data Structure Proofs registries under a Specification Required policy as described in [RFC8126].

> I failed to find these. Can we please have pointers to where those are defined?