### PR TITLE
Use direct quote from RFC9162

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -337,7 +337,10 @@ inclusion-proof = bstr .cbor [
 
 The term `leaf-index` is used for alignment with the use established in {{Section 2.1.3.2 of RFC9162}}.
 
-Note that {{RFC9162}} defines that verification MUST fail if leaf-index is >= tree-size, and inclusion proofs are defined only for leaf nodes.
+Note that {{RFC9162}} defines inclusion proofs only for leaf nodes, and that:
+
+> If leaf_index is greater than or equal to tree_size, then fail the proof verification.
+
 The identifying index of a leaf node is relative to all nodes in the tree size for which the proof was obtained.
 
 ### Receipt of Inclusion


### PR DESCRIPTION
Towards #64 

> (1) CURRENT:

> Note that [RFC9162] defines that verification MUST fail if leaf-index
> is >= tree-size, and inclusion proofs are defined only for leaf
nodes.


> May format this as a quote to insist this is not a NEW behavior.