### PR TITLE
Fix registration wording

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -299,7 +299,7 @@ Each verifiable data structure specification applying for inclusion in this regi
 Each specification MUST define how to produce and consume the supported proof types.
 See {{sec-rfc-9162-verifiable-data-structure-definition}} as an example.
 
-Where a specification supports a choice of hash algorithm, an IANA registration must be made for each individually supported algorithm.
+Where a specification supports a choice of hash algorithm, a separate IANA registration must be made for each supported algorithm.
 For example, to provide for both SHA256 and SHA3_256 with {{RFC9162}},
 both "RFC9162_SHA256" and "RFC9162_SHA3_256" require entries in the relevant IANA registries.
 


### PR DESCRIPTION
Towards #66 

> Section 4.3.1, "an IANA registration must be made for each individually supported algorithm" => "a separate IANA registration must be made for each supported algorithm"