### PR TITLE
Wrap proof paths in nested arrays in EDN examples

### DIFF
--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -326,7 +326,7 @@ The following informative EDN is provided:
         / protected   / <<{
           / kid / 4 : h'abcdef12...34567890',
           / algorithm / 1 : -7,  # ES256
-          / vds       / 395 : 1, # RFC9162 SHA-256
+          / vds       / 395 : 1, # RFC9162_SHA256
         }>>,
         / unprotected / {
           / proofs / 396 : {

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -559,7 +559,7 @@ An example EDN for a Receipt containing a consistency proof for RFC9162_SHA256 w
 / cose-sign1 / 18([
   / protected   / <<{
     / algorithm / 1 : -7,  # ES256
-    / vds       / 395 : 1, # RFC9162 SHA-256
+    / vds       / 395 : 1, # RFC9162_SHA256
   }>>,
   / unprotected / {
     / proofs / 396 : {

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -459,7 +459,7 @@ An EDN example for a Receipt containing an inclusion proof for RFC9162_SHA256 wi
 / cose-sign1 / 18([
   / protected   / <<{
     / algorithm / 1 : -7,  # ES256
-    / vds       / 395 : 1, # RFC9162 SHA-256
+    / vds       / 395 : 1, # RFC9162_SHA256
   }>>,
   / unprotected / {
     / proofs / 396 : {

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -297,15 +297,15 @@ The following informative EDN is provided:
 / cose-sign1 / 18([
   / protected   / <<{
     / kid / 4 : h'bc297b51...e4edf0de',
-    / algorithm / 1 : -7,  # ES256
+    / algorithm / 1 : -7,  / ES256
   }>>,
   / unprotected / {
     / receipts / 394 : [
       <</ cose-sign1 / 18([
         / protected   / <<{
           / kid / 4 : h'abcdef12...34567890',
-          / algorithm / 1 : -7,  # ES256
-          / vds       / 395 : 1, # RFC9162 SHA-256
+          / algorithm / 1 : -7,  / ES256
+          / vds       / 395 : 1, / RFC9162_SHA256
         }>>,
         / unprotected / {
           / proofs / 396 : {
@@ -325,8 +325,8 @@ The following informative EDN is provided:
       <</ cose-sign1 / 18([
         / protected   / <<{
           / kid / 4 : h'abcdef12...34567890',
-          / algorithm / 1 : -7,  # ES256
-          / vds       / 395 : 1, # RFC9162 SHA-256
+          / algorithm / 1 : -7,  / ES256
+          / vds       / 395 : 1, / RFC9162_SHA256
         }>>,
         / unprotected / {
           / proofs / 396 : {
@@ -458,8 +458,8 @@ An EDN example for a Receipt containing an inclusion proof for RFC9162_SHA256 wi
 ~~~~ cbor-diag
 / cose-sign1 / 18([
   / protected   / <<{
-    / algorithm / 1 : -7,  # ES256
-    / vds       / 395 : 1, # RFC9162 SHA-256
+    / algorithm / 1 : -7,  / ES256
+    / vds       / 395 : 1, / RFC9162_SHA256
   }>>,
   / unprotected / {
     / proofs / 396 : {
@@ -558,8 +558,8 @@ An example EDN for a Receipt containing a consistency proof for RFC9162_SHA256 w
 ~~~~ cbor-diag
 / cose-sign1 / 18([
   / protected   / <<{
-    / algorithm / 1 : -7,  # ES256
-    / vds       / 395 : 1, # RFC9162 SHA-256
+    / algorithm / 1 : -7,  / ES256
+    / vds       / 395 : 1, / RFC9162_SHA256
   }>>,
   / unprotected / {
     / proofs / 396 : {

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -300,7 +300,7 @@ The following informative EDN is provided:
     / algorithm / 1 : -7,  # ES256
   }>>,
   / unprotected / {
-    / receipts / 394 : {
+    / receipts / 394 : [
       <</ cose-sign1 / 18([
         / protected   / <<{
           / kid / 4 : h'abcdef12...34567890',
@@ -344,7 +344,7 @@ The following informative EDN is provided:
         / payload     / null,
         / signature   / h'36581f38...a5581960'
       ])>>
-    },
+    ],
   },
   / payload     / h'0167c57c...deeed6d4',
   / signature   / h'2544f2ed...5840893b'

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -312,8 +312,9 @@ The following informative EDN is provided:
             / inclusion / -1 : [
               <<[
                 / size / 9, / leaf / 8,
-                / inclusion path /
-                h'7558a95f...e02e35d6'
+                / inclusion path / [
+                  h'7558a95f...e02e35d6'
+                ]
               ]>>
             ],
           },
@@ -332,9 +333,10 @@ The following informative EDN is provided:
             / inclusion / -1 : [
               <<[
                 / size / 6, / leaf / 5,
-                / inclusion path /
-                h'9352f974...4ffa7ce0',
-                h'54806f32...f007ea06'
+                / inclusion path / [
+                  h'9352f974...4ffa7ce0',
+                  h'54806f32...f007ea06'
+                ]
               ]>>
             ],
           },
@@ -464,10 +466,11 @@ An EDN example for a Receipt containing an inclusion proof for RFC9162_SHA256 wi
       / inclusion / -1 : [
         <<[
           / size / 20, / leaf / 17,
-          / inclusion path /
-          h'fc9f050f...221c92cb',
-          h'bd0136ad...6b28cf21',
-          h'd68af9d6...93b1632b'
+          / inclusion path / [
+            h'fc9f050f...221c92cb',
+            h'bd0136ad...6b28cf21',
+            h'd68af9d6...93b1632b'
+          ]
         ]>>
       ],
     },
@@ -563,13 +566,14 @@ An example EDN for a Receipt containing a consistency proof for RFC9162_SHA256 w
       / consistency / -2 : [
         <<[
           / old / 20, / new / 104,
-          / consistency path /
-          h'e5b3e764...c4a813bc',
-          h'87e8a084...4f529f69',
-          h'f712f76d...92a0ff36',
-          h'd68af9d6...93b1632b',
-          h'249efab6...b7614ccd',
-          h'85dd6293...38914dc1'
+          / consistency path / [
+            h'e5b3e764...c4a813bc',
+            h'87e8a084...4f529f69',
+            h'f712f76d...92a0ff36',
+            h'd68af9d6...93b1632b',
+            h'249efab6...b7614ccd',
+            h'85dd6293...38914dc1'
+          ]
         ]>>
       ],
     },

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -297,15 +297,15 @@ The following informative EDN is provided:
 / cose-sign1 / 18([
   / protected   / <<{
     / kid / 4 : h'bc297b51...e4edf0de',
-    / algorithm / 1 : -7,  / ES256
+    / algorithm / 1 : -7,  # ES256
   }>>,
   / unprotected / {
     / receipts / 394 : [
       <</ cose-sign1 / 18([
         / protected   / <<{
           / kid / 4 : h'abcdef12...34567890',
-          / algorithm / 1 : -7,  / ES256
-          / vds       / 395 : 1, / RFC9162_SHA256
+          / algorithm / 1 : -7,  # ES256
+          / vds       / 395 : 1, # RFC9162 SHA-256
         }>>,
         / unprotected / {
           / proofs / 396 : {
@@ -325,8 +325,8 @@ The following informative EDN is provided:
       <</ cose-sign1 / 18([
         / protected   / <<{
           / kid / 4 : h'abcdef12...34567890',
-          / algorithm / 1 : -7,  / ES256
-          / vds       / 395 : 1, / RFC9162_SHA256
+          / algorithm / 1 : -7,  # ES256
+          / vds       / 395 : 1, # RFC9162 SHA-256
         }>>,
         / unprotected / {
           / proofs / 396 : {
@@ -458,8 +458,8 @@ An EDN example for a Receipt containing an inclusion proof for RFC9162_SHA256 wi
 ~~~~ cbor-diag
 / cose-sign1 / 18([
   / protected   / <<{
-    / algorithm / 1 : -7,  / ES256
-    / vds       / 395 : 1, / RFC9162_SHA256
+    / algorithm / 1 : -7,  # ES256
+    / vds       / 395 : 1, # RFC9162 SHA-256
   }>>,
   / unprotected / {
     / proofs / 396 : {
@@ -558,8 +558,8 @@ An example EDN for a Receipt containing a consistency proof for RFC9162_SHA256 w
 ~~~~ cbor-diag
 / cose-sign1 / 18([
   / protected   / <<{
-    / algorithm / 1 : -7,  / ES256
-    / vds       / 395 : 1, / RFC9162_SHA256
+    / algorithm / 1 : -7,  # ES256
+    / vds       / 395 : 1, # RFC9162 SHA-256
   }>>,
   / unprotected / {
     / proofs / 396 : {

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -305,7 +305,7 @@ The following informative EDN is provided:
         / protected   / <<{
           / kid / 4 : h'abcdef12...34567890',
           / algorithm / 1 : -7,  # ES256
-          / vds       / 395 : 1, # RFC9162 SHA-256
+          / vds       / 395 : 1, # RFC9162_SHA256
         }>>,
         / unprotected / {
           / proofs / 396 : {


### PR DESCRIPTION
## Summary

Reconciles the four EDN blocks in the draft against the AUTH48 RFC Ed version of RFC 9942 (https://www.rfc-editor.org/authors/rfc9942.txt) and applies corrections for two EDN issues in that version. Since RFC 9942 has not been published yet, these are AUTH48-stage corrections — no errata involved.

### Inconsistencies vs AUTH48 RFC 9942 found

| # | Issue | AUTH48 RFC 9942 | Pre-PR draft | Resolution |
|---|---|---|---|---|
| 1 | `receipts` value | `/ receipts / 394 : [ ... ]` (array) | `/ receipts / 394 : { ... }` (map) | Fixed in #105, merged into this branch |
| 2 | Path bracketing in `inclusion-path` / `consistency-path` | Inconsistent — Fig 2 receipt #2 and Fig 6 wrap in `[ ... ]`; Fig 2 receipt #1 and Fig 9 emit a bare bstr / flat list **(violates the CDDL `[ + bstr ]`)** | Matched AUTH48 inconsistency | Wrapped all four paths in `[ ... ]` to match the CDDL — needs corresponding AUTH48 correction in the RFC text |
| 3 | Trailing comments | `/ ES256`, `/ RFC9162_SHA256` (paired-slash, **unclosed**) | `# ES256`, `# RFC9162 SHA-256` (tail comment) | **Keep `#` form** — see below; needs corresponding AUTH48 correction in the RFC text |

### Why the `#` tail-comment form is kept

In CBOR EDN (RFC 8949 §8 and draft-ietf-cbor-edn-literals), `/ ... /` is a paired-slash block comment that must be closed with another `/`. The AUTH48 RFC 9942 text writes `/ ES256\n` and `/ RFC9162_SHA256\n` as unclosed paired-slash openers, which is not valid EDN — a strict parser would consume content until the next `/` it found. The `# ...` tail-comment form, on the other hand, is well-defined (terminated by end of line) and parses correctly. The draft therefore keeps `#` and diverges from the AUTH48 EDN here on purpose.

### Commits

- `0900fba` Wrap proof paths in nested arrays in EDN examples
- `e1c0039` (#105, Carsten) Use brackets for the receipts array, not braces
- `1e0d10b` Revert slash-comment sync — keep `#` tail comments (valid EDN)

### For community / AUTH48 discussion

Two issues in the current AUTH48 RFC 9942 text need authors-stage corrections to keep the published RFC consistent with its own CDDL and with valid EDN:

- The `inclusion-path` / `consistency-path` bracketing in Figure 2 receipt #1 and Figure 9 does not satisfy the RFC's own CDDL.
- The `/ ES256` / `/ RFC9162_SHA256` unclosed paired-slash openers are not valid EDN; they should be `# ES256` / `# RFC9162_SHA256`.

## Test plan

- [x] `make` passes (kramdown-rfc + xml2rfc-html + xml2rfc-txt)
- [x] Rendered TXT spot-checked: `receipts: 394 : [`, `inclusion path / [`, `consistency path / [`, `# ES256` / `# RFC9162 SHA-256` tail comments preserved
- [ ] WG / AD review of the bracket correction relative to the AUTH48 RFC text
- [ ] Submit corresponding AUTH48 corrections for items #2 and #3 in the RFC text

🤖 Generated with [Claude Code](https://claude.com/claude-code)