### PR TITLE
Align CDDL with RFC Editor's rfc9942.xml

### DIFF
--- a/auth48/rfc9942.xml
+++ b/auth48/rfc9942.xml
@@ -305,9 +305,9 @@ Unprotected_Header = {
 }
 
 COSE_Sign1 = [
-  protected   : bstr .cbor Protected_Header,
-  unprotected : Unprotected_Header,
-  payload     : bstr / nil,
+  protected   : bstr .cbor Protected_Header
+  unprotected : Unprotected_Header
+  payload     : bstr / nil
   signature   : bstr
 ]
 
@@ -346,10 +346,10 @@ RFC9162_SHA256_Inclusion_Proofs = [
   + RFC9162_SHA256_Inclusion_Proof
 ]
 
-RFC9162_SHA256_Inclusion_Proof = bstr .cbor [
+RFC9162_SHA256_Inclusion_Proof_Content = [
   tree_size: uint,
   leaf_index: uint,
-  inclusion_path: [ + bstr ]
+  inclusion_path:[ + bstr ]
 ]
 
 
@@ -382,7 +382,7 @@ RFC9162_SHA256_Consistency_Proofs = [
   + RFC9162_SHA256_Consistency_Proof
 ]
 
-RFC9162_SHA256_Consistency_Proof = bstr .cbor [
+RFC9162_SHA256_Consistency_Proof_Content = [
    tree_size_1: uint,
    tree_size_2: uint,
    consistency_path: [ + bstr ]
@@ -539,7 +539,7 @@ The string identifier for this Verifiable Data Structure is "RFC9162_SHA256", a 
         <figure anchor="rfc9162-sha256-cbor-inclusion-proof">
           <name>CBOR-Encoded Inclusion Proof for RFC9162_SHA256</name>
           <sourcecode type="cddl"><![CDATA[
-inclusion-proof = bstr .cbor [
+inclusion-proof-content = [
 
     ; tree size at current Merkle Tree root
     tree-size: uint
@@ -686,7 +686,7 @@ If the resulting signature cannot be verified, the signature may have been tampe
         <figure anchor="rfc9162_sha256_consistency_proof">
           <name>CBOR-Encoded Consistency Proof for RFC9162_SHA256</name>
           <sourcecode type="cddl"><![CDATA[
-consistency-proof =  bstr .cbor [
+consistency-proof-content = [
 
     ; older Merkle Tree size
     tree-size-1: uint

--- a/draft-ietf-cose-merkle-tree-proofs.md
+++ b/draft-ietf-cose-merkle-tree-proofs.md
@@ -211,9 +211,9 @@ Unprotected_Header = {
 }
 
 COSE_Sign1 = [
-  protected   : bstr .cbor Protected_Header,
-  unprotected : Unprotected_Header,
-  payload     : bstr / nil,
+  protected   : bstr .cbor Protected_Header
+  unprotected : Unprotected_Header
+  payload     : bstr / nil
   signature   : bstr
 ]
 
@@ -249,10 +249,10 @@ RFC9162_SHA256_Verifiable_Inclusion_Proofs = {
 
 RFC9162_SHA256_Inclusion_Proofs = [ + RFC9162_SHA256_Inclusion_Proof ]
 
-RFC9162_SHA256_Inclusion_Proof = bstr .cbor [
+RFC9162_SHA256_Inclusion_Proof_Content = [
   tree_size: uint,
   leaf_index: uint,
-  inclusion_path: [ + bstr ]
+  inclusion_path:[ + bstr ]
 ]
 
 
@@ -282,7 +282,7 @@ RFC9162_SHA256_Verifiable_Consistency_Proofs = {
 
 RFC9162_SHA256_Consistency_Proofs = [ + RFC9162_SHA256_Consistency_Proof ]
 
-RFC9162_SHA256_Consistency_Proof = bstr .cbor [
+RFC9162_SHA256_Consistency_Proof_Content = [
    tree_size_1: uint,
    tree_size_2: uint,
    consistency_path: [ + bstr ]
@@ -392,7 +392,7 @@ See {{Section 2.1.3.1 of RFC9162}} (Generating an Inclusion Proof), for a comple
 The CBOR representation of an inclusion proof for RFC9162_SHA256 is:
 
 ~~~~ cddl
-inclusion-proof = bstr .cbor [
+inclusion-proof-content = [
 
     ; tree size at current Merkle root
     tree-size: uint
@@ -498,7 +498,7 @@ See {{Section 2.1.4.1 of RFC9162}} (Generating a Consistency Proof), for a compl
 The cbor representation of a consistency proof for RFC9162_SHA256 is:
 
 ~~~~ cddl
-consistency-proof =  bstr .cbor [
+consistency-proof-content = [
 
     ; older Merkle root tree size
     tree-size-1: uint

--- a/examples/consistency-receipt.cddl
+++ b/examples/consistency-receipt.cddl
@@ -27,7 +27,7 @@ RFC9162_SHA256_Verifiable_Consistency_Proofs = {
 
 RFC9162_SHA256_Consistency_Proofs = [ + RFC9162_SHA256_Consistency_Proof ]
 
-RFC9162_SHA256_Consistency_Proof = bstr .cbor [
+RFC9162_SHA256_Consistency_Proof_Content = [
    tree_size_1: uint,
    tree_size_2: uint,
    consistency_path: [ + bstr ]

--- a/examples/inclusion-receipt.cddl
+++ b/examples/inclusion-receipt.cddl
@@ -27,8 +27,8 @@ RFC9162_SHA256_Verifiable_Inclusion_Proofs = {
 
 RFC9162_SHA256_Inclusion_Proofs = [ + RFC9162_SHA256_Inclusion_Proof ]
 
-RFC9162_SHA256_Inclusion_Proof = bstr .cbor [
+RFC9162_SHA256_Inclusion_Proof_Content = [
   tree_size: uint,
   leaf_index: uint,
-  inclusion_path: [ + bstr ]
+  inclusion_path:[ + bstr ]
 ]


### PR DESCRIPTION
This PR aligns the CDDL definitions in the markdown source, `auth48/rfc9942.xml`, and `examples/*.cddl` with the RFC Editor's current copy at `https://auth48-transition.rfc-editor.org/authors/rfc9942.xml`.

## Changes

### 1. Proof type naming (`_Content` suffix)

The RFC Editor's CDDL uses `_Content` suffixed names for the inner array structures, without the `bstr .cbor` wrapper:

**Figure 1 (comprehensive CDDL):**
- `RFC9162_SHA256_Inclusion_Proof = bstr .cbor [` → `RFC9162_SHA256_Inclusion_Proof_Content = [`
- `RFC9162_SHA256_Consistency_Proof = bstr .cbor [` → `RFC9162_SHA256_Consistency_Proof_Content = [`

**Section 5 (per-proof-type CDDL):**
- `inclusion-proof = bstr .cbor [` → `inclusion-proof-content = [`
- `consistency-proof = bstr .cbor [` → `consistency-proof-content = [`

### 2. COSE_Sign1 commas

Removed trailing commas from COSE_Sign1 array members in Figure 1 to match the RFC Editor:

```
COSE_Sign1 = [
  protected   : bstr .cbor Protected_Header
  unprotected : Unprotected_Header
  payload     : bstr / nil
  signature   : bstr
]
```

### 3. Spacing fix

Removed the space after the colon in `inclusion_path:[ + bstr ]` to match the RFC Editor.

## Files changed

- `draft-ietf-cose-merkle-tree-proofs.md`
- `auth48/rfc9942.xml`
- `examples/inclusion-receipt.cddl`
- `examples/consistency-receipt.cddl`

Relates to #110.