### PR TITLE
Revert abbreviation expansion in CDDL comment to match RFC Editor copy

### DIFF
--- a/auth48/rfc9942.xml
+++ b/auth48/rfc9942.xml
@@ -219,7 +219,7 @@ COSE_Sign1 = [
 Receipt = Receipt_For_Inclusion / Receipt_For_Consistency
 
 ; Note the proof formats shown here are for RFC9162_SHA256.
-; Other Verifiable Data Structures may have different proof formats.
+; Other VDSs may have different proof formats.
 
 
 Receipt_For_Inclusion = #6.18(Signed_Inclusion_Proof)


### PR DESCRIPTION
See https://github.com/cose-wg/draft-ietf-cose-merkle-tree-proofs/issues/110#issuecomment-4711053852