### PR TITLE
auth48: diff our RFC 9942 edits against the RFC Editor's current copy

### DIFF
--- a/auth48/rfc9942.xml
+++ b/auth48/rfc9942.xml
@@ -195,7 +195,7 @@ Security analysis <bcp14>MUST</bcp14> be conducted prior to migrating to new str
 <figure anchor="fig-receipts-cddl">
           <name>CDDL for a COSE_Sign1 with Attached Receipts</name>
           <sourcecode type="cddl"><![CDATA[
-Signature_With_Receipt = /6.18(COSE_Sign1)
+Signature_With_Receipt = #6.18(COSE_Sign1)
 
 cose-label = int / text
 cose-values = any
@@ -222,7 +222,7 @@ Receipt = Receipt_For_Inclusion / Receipt_For_Consistency
 ; Other VDSs may have different proof formats.
 
 
-Receipt_For_Inclusion = /6.18(Signed_Inclusion_Proof)
+Receipt_For_Inclusion = #6.18(Signed_Inclusion_Proof)
 
 Signed_Inclusion_Proof = [
   protected   :
@@ -251,6 +251,8 @@ RFC9162_SHA256_Inclusion_Proofs = [
   + RFC9162_SHA256_Inclusion_Proof
 ]
 
+RFC9162_SHA256_Inclusion_Proof = bstr .cbor RFC9162_SHA256_Inclusion_Proof_Content
+
 RFC9162_SHA256_Inclusion_Proof_Content = [
   tree_size: uint,
   leaf_index: uint,
@@ -258,7 +260,7 @@ RFC9162_SHA256_Inclusion_Proof_Content = [
 ]
 
 
-Receipt_For_Consistency = /6.18(Signed_Consistency_Proof)
+Receipt_For_Consistency = #6.18(Signed_Consistency_Proof)
 
 Signed_Consistency_Proof = [
   protected   :
@@ -286,6 +288,8 @@ RFC9162_SHA256_Verifiable_Consistency_Proofs = {
 RFC9162_SHA256_Consistency_Proofs = [
   + RFC9162_SHA256_Consistency_Proof
 ]
+
+RFC9162_SHA256_Consistency_Proof = bstr .cbor RFC9162_SHA256_Consistency_Proof_Content
 
 RFC9162_SHA256_Consistency_Proof_Content = [
    tree_size_1: uint,


### PR DESCRIPTION
## Why

A review artifact to surface exactly how our `auth48/rfc9942.xml` differs from the RFC Editor's current AUTH48 copy.

The two commits are intentional and structured for review:

1. **`set RFC Editor's rfc9942.xml as base`** — verbatim copy fetched from <https://auth48-transition.rfc-editor.org/authors/rfc9942.xml> (RFC 9942, `docName draft-ietf-cose-merkle-tree-proofs-18`).
2. **`apply our edits on top of RFC Editor base`** — overlays our maintained `auth48/rfc9942.xml` (from `main`).

So the **second commit's diff == our changes vs the RFC Editor's copy**. The branch tip is content-identical to `main`, so this is a **comparison/review vehicle, not a merge candidate** (merging is a content no-op).

## The differences (all in the CDDL block)

1. **CBOR tag notation (3×):** editor `/6.18(...)` vs ours `#6.18(...)` — `Signature_With_Receipt`, `Receipt_For_Inclusion`, `Receipt_For_Consistency`. `#6.<tag>(type)` is the standard CDDL tag syntax; a leading `/` reads as a type-choice operator.
2. **Two added `.cbor` proof definitions** the editor copy lacks:
   - `RFC9162_SHA256_Inclusion_Proof = bstr .cbor RFC9162_SHA256_Inclusion_Proof_Content`
   - `RFC9162_SHA256_Consistency_Proof = bstr .cbor RFC9162_SHA256_Consistency_Proof_Content`

## Notes

- "Our version" here is `main`. It differs from `sync_editor_0615` by a single line (`VDSs` vs `Verifiable Data Structures`).
- Draft, for review only.