### PR TITLE
Uncomment validation script for the editor copy in ghpages workflow

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -56,7 +56,7 @@ jobs:
         set -eo pipefail
         tmpdir="$(mktemp -d)"
         trap 'rm -rf "$tmpdir"' EXIT
-        curl -fsSLo "$tmpdir/rfc9942.xml" https://www.rfc-editor.org/authors/rfc9942.xml
+        curl --retry 3 --retry-all-errors -fsSLo "$tmpdir/rfc9942.xml" https://www.rfc-editor.org/authors/rfc9942.xml
         ./examples/validate-cbor-examples.sh "$tmpdir/rfc9942.xml"
 
     - name: "Setup"

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -57,7 +57,7 @@ jobs:
         tmpdir="$(mktemp -d)"
         trap 'rm -rf "$tmpdir"' EXIT
         curl -fsSLo "$tmpdir/rfc9942.xml" https://www.rfc-editor.org/authors/rfc9942.xml
-        # ./examples/validate-cbor-examples.sh "$tmpdir/rfc9942.xml"
+        ./examples/validate-cbor-examples.sh "$tmpdir/rfc9942.xml"
 
     - name: "Setup"
       id: setup


### PR DESCRIPTION
The CDDL/EDN validation of the editor's copy <strike>should</strike> does work now. Making the CI run against it means we can catch any breaks introduced there more easily.